### PR TITLE
Fix YouTube embeds in the guide

### DIFF
--- a/guide.html
+++ b/guide.html
@@ -150,7 +150,7 @@ img {
         
         <table width="100%" border="0" cellspacing="0" cellpadding="5">
           <tr>
-            <td width="250"><div class="vid"><iframe title="YouTube video player" width="212" height="174" src="http://www.youtube.com/embed/609nhVzg-5Q" frameborder="0" allowfullscreen></iframe></div></td>
+            <td width="250"><div class="vid"><iframe title="YouTube video player" width="212" height="174" src="https://www.youtube.com/embed/609nhVzg-5Q" frameborder="0" allowfullscreen></iframe></div></td>
             <td valign="top">
               <p>First, watch the beginner's method video.</p>
               <p>- Here is a link to the <a href="https://defhacks.github.io/badmephisto-mirror/begsoln/" target="_blank">Printable Page</a> for my beginner's method.</p>
@@ -162,7 +162,7 @@ img {
         <table width="100%" border="0" cellspacing="0" cellpadding="5">
           <tr>
             <td width="250"><div class="vid">
-              <iframe title="YouTube video player" width="212" height="174" src="http://www.youtube.com/embed/ad2NdgoAg8I" frameborder="0" allowfullscreen></iframe>
+              <iframe title="YouTube video player" width="212" height="174" src="https://www.youtube.com/embed/ad2NdgoAg8I" frameborder="0" allowfullscreen></iframe>
             </div></td>
             <td valign="top"><p>Once you solve the cube yourself at least once (even if you are still looking up the algorithms), check my intro to speedcubing video.</p>
               <p>If you get all excited at this point, and decide to give speedcubing a try, here are some more useful links:</p>
@@ -175,7 +175,7 @@ img {
     <h2>Perfecting your beginner's method</h2>
         <table width="100%" border="0" cellspacing="0" cellpadding="5">
           <tr>
-            <td width="250"><div class="vid"><iframe title="YouTube video player" width="212" height="174" src="http://www.youtube.com/embed/EOEZlFAsSL0" frameborder="0" allowfullscreen></iframe></div></td>
+            <td width="250"><div class="vid"><iframe title="YouTube video player" width="212" height="174" src="https://www.youtube.com/embed/EOEZlFAsSL0" frameborder="0" allowfullscreen></iframe></div></td>
             <td valign="top">First thing you might want to do is start standardizing your solves to make them look very similar. This video explains the idea.</td>
           </tr>
         </table>
@@ -185,8 +185,8 @@ img {
         
         <table width="700" border="0" cellspacing="0" cellpadding="0">
           <tr>
-            <td><div class="vid"><iframe title="YouTube video player" width="212" height="174" src="http://www.youtube.com/embed/k-xbcAMfWwM" frameborder="0" allowfullscreen></iframe></div></td>
-            <td><div class="vid"><iframe title="YouTube video player" width="212" height="174" src="http://www.youtube.com/embed/4GxLM_dZqg4" frameborder="0" allowfullscreen></iframe></div></td>
+            <td><div class="vid"><iframe title="YouTube video player" width="212" height="174" src="https://www.youtube.com/embed/k-xbcAMfWwM" frameborder="0" allowfullscreen></iframe></div></td>
+            <td><div class="vid"><iframe title="YouTube video player" width="212" height="174" src="https://www.youtube.com/embed/4GxLM_dZqg4" frameborder="0" allowfullscreen></iframe></div></td>
           </tr>
         </table>
         
@@ -198,14 +198,14 @@ img {
         <table width="100%" border="0" cellspacing="0" cellpadding="5">
           <tr>
             <td width="250"><div class="vid">
-              <iframe title="YouTube video player" width="212" height="174" src="http://www.youtube.com/embed/DTYvklyOpVM" frameborder="0" allowfullscreen></iframe>
+              <iframe title="YouTube video player" width="212" height="174" src="https://www.youtube.com/embed/DTYvklyOpVM" frameborder="0" allowfullscreen></iframe>
             </div></td>
             <td valign="top"><p>While you are making sense of F2L, you ca go ahead and start learning more advanced methods for solving the last layer. Now is a good time to start learning the 2-look OLL:</p>
             <p>You can find a printable sheet for the 2-look OLL <a href="https://defhacks.github.io/badmephisto-mirror/2LookOLL.pdf" target="_blank">here</a>, or you can also find it in my iPhone app.</p></td>
           </tr>
           <tr>
             <td width="250"><div class="vid">
-              <iframe title="YouTube video player" width="212" height="174" src="http://www.youtube.com/embed/S61q3FYVFis" frameborder="0" allowfullscreen></iframe>
+              <iframe title="YouTube video player" width="212" height="174" src="https://www.youtube.com/embed/S61q3FYVFis" frameborder="0" allowfullscreen></iframe>
             </div></td>
             <td valign="top"><p>After 2-look OLL, you can start learning the 2-look PLL algorithms:</p>
             <p>You can find a printable sheet for the 2-look PLL <a href="https://defhacks.github.io/badmephisto-mirror/2LookPLL.pdf" target="_blank">here</a>, or you can also find it in my iPhone app.</p></td>
@@ -216,8 +216,8 @@ img {
         
         <table width="700" border="0" cellspacing="0" cellpadding="0">
           <tr>
-            <td><div class="vid"><iframe title="YouTube video player"  width="212" height="174" src="http://www.youtube.com/embed/hY_FbpdNRCQ" frameborder="0" allowfullscreen></iframe></div></td>
-            <td><div class="vid"><iframe title="YouTube video player" width="212" height="174" src="http://www.youtube.com/embed/BTydBg21aaw" frameborder="0" allowfullscreen></iframe></div></td>
+            <td><div class="vid"><iframe title="YouTube video player"  width="212" height="174" src="https://www.youtube.com/embed/hY_FbpdNRCQ" frameborder="0" allowfullscreen></iframe></div></td>
+            <td><div class="vid"><iframe title="YouTube video player" width="212" height="174" src="https://www.youtube.com/embed/BTydBg21aaw" frameborder="0" allowfullscreen></iframe></div></td>
           </tr>
         </table>
         
@@ -225,13 +225,13 @@ img {
         <p>When you start to become very comfortable with the F2L, and being able to solve it easily, you can start trying to perfect it. I have many videos on how you can go about doing this.</p>
         <table width="100%" border="0" cellspacing="0" cellpadding="5">
           <tr>
-            <td width="19%"><iframe title="YouTube video player" width="212" height="174" src="http://www.youtube.com/embed/RdSiQQ9VSEY" frameborder="0" allowfullscreen></iframe></td>
+            <td width="19%"><iframe title="YouTube video player" width="212" height="174" src="https://www.youtube.com/embed/RdSiQQ9VSEY" frameborder="0" allowfullscreen></iframe></td>
             <td width="33%" valign="top">First, maybe you want to start trying to use some finger-tricks. I go over some of them in this video.</td>
-            <td width="19%" valign="top"><iframe title="YouTube video player"  width="212" height="174" src="http://www.youtube.com/embed/pnkSZZ6OoQ4" frameborder="0" allowfullscreen></iframe></td>
+            <td width="19%" valign="top"><iframe title="YouTube video player"  width="212" height="174" src="https://www.youtube.com/embed/pnkSZZ6OoQ4" frameborder="0" allowfullscreen></iframe></td>
             <td width="29%" valign="top">Next up, we have some tips on practicing the F2L.</td>
           </tr>
           <tr>
-            <td><iframe title="YouTube video player" width="212" height="174" src="http://www.youtube.com/embed/lu0TkcwVUT4" frameborder="0" allowfullscreen></iframe></td>
+            <td><iframe title="YouTube video player" width="212" height="174" src="https://www.youtube.com/embed/lu0TkcwVUT4" frameborder="0" allowfullscreen></iframe></td>
             <td valign="top">I also made a quick video about best ways to pop out a croner from the bottom to pair up with its edge</td>
             <td valign="top"><iframe title="YouTube video player" width="212" height="174" src="http://www.youtube.com/embed/pzkHrz8x2eo" frameborder="0" allowfullscreen></iframe></td>
             <td valign="top">The most important idea you should be getting out of all of it is that tracking the F2L pieces and always looking ahead is extremely important. Here is a sample of what my thought process looks like while I solve the F2L.</td>

--- a/guide.html
+++ b/guide.html
@@ -248,15 +248,15 @@ img {
         <p>Once you are doing well with your F2L and your cross, you want to slowly start learning the PLLs. There are 21 algorithms for this stage, but you already know many of them. Check out <a href="https://defhacks.github.io/badmephisto-mirror/pll.html" target="_blank">my PLL page</a>, which contains many good resources and links to printable sheets, etc.</p>
         <table width="100%" border="0" cellspacing="0" cellpadding="5">
           <tr>
-            <td width="250"><iframe title="YouTube video player" width="212" height="174" src="http://www.youtube.com/embed/niCubJ779KU" frameborder="0" allowfullscreen></iframe></td>
+            <td width="250"><iframe title="YouTube video player" width="212" height="174" src="https://www.youtube.com/embed/niCubJ779KU" frameborder="0" allowfullscreen></iframe></td>
             <td valign="top">Here are some tips for memorizing the PLL's.</td>
           </tr>
           <tr>
-            <td><iframe title="YouTube video player" width="212" height="174" src="http://www.youtube.com/embed/0Id44xvrvWo" frameborder="0" allowfullscreen></iframe></td>
+            <td><iframe title="YouTube video player" width="212" height="174" src="https://www.youtube.com/embed/0Id44xvrvWo" frameborder="0" allowfullscreen></iframe></td>
             <td valign="top">Here are tips for learning both PLLs and OLLs. It's more about how do you remember these algorithms in the first place. How do you memorize them? This gives some tips, and try to convince you that even though there are many algorithms, it's not as bad as it seems.</td>
           </tr>
           <tr>
-            <td><iframe title="YouTube video player" width="212" height="174" src="http://www.youtube.com/embed/qBYycb7hR4Y" frameborder="0" allowfullscreen></iframe></td>
+            <td><iframe title="YouTube video player" width="212" height="174" src="https://www.youtube.com/embed/qBYycb7hR4Y" frameborder="0" allowfullscreen></iframe></td>
             <td valign="top">Finally, here is my attempt to show you approximately how I go about recognizing the PLL's. Basically, there are some features that come up on the top layer that give you strong indication of which PLL you should execute, and in this video I go over them.</td>
           </tr>
         </table>
@@ -267,7 +267,7 @@ img {
         <h2>Learning the OLL</h2> 
         <table width="100%" border="0" cellspacing="0" cellpadding="5">
           <tr>
-            <td width="250"><iframe title="YouTube video player" width="212" height="174" src="http://www.youtube.com/embed/lPvF21KeAPE" frameborder="0" allowfullscreen></iframe></td>
+            <td width="250"><iframe title="YouTube video player" width="212" height="174" src="https://www.youtube.com/embed/lPvF21KeAPE" frameborder="0" allowfullscreen></iframe></td>
             <td valign="top"><p>Once you know most of the PLL's, you are ready to start learning the OLL's. The first important video that you should have already watched is listed together with the PLL's above. It's called &quot;Tips/Tricks for learning OLL/PLL [New!]&quot;</p>
             <p>Finally, I have one more video on tips for learning OLL's, and some other surrounding tricks.</p>
             <p>You can find more details on my <a href="https://defhacks.github.io/badmephisto-mirror/oll.html" target="_blank">OLL page</a>. </p></td>


### PR DESCRIPTION
The YouTube embeds aren't showing up in guide.html because the GitHub page is served on https but the embeds are http.

I've updated the URLs and verified that they work at https://georgeh.github.io/badmephisto-mirror/guide.html